### PR TITLE
Update printer-Ender3V2-CRtouch-V4.2.7.cfg

### DIFF
--- a/printer_configrations/printer-Ender3V2-CRtouch-V4.2.7.cfg
+++ b/printer_configrations/printer-Ender3V2-CRtouch-V4.2.7.cfg
@@ -59,6 +59,8 @@ gcode:
     G1 Z{z_safe} F900
     G90
     G1 X{x_park} Y{y_park} F6000
+    G91
+    G1 Z-{z_safe} F900 # return to print height
   {% else %}
     {action_respond_info("Printer not homed")}
   {% endif %}


### PR DESCRIPTION
added code to allow resume, after power failure (while paused)

Reason for this is as follows.

South Africa has regular power outages (usually 3 per day, for 2-4 hours).
To save our prints, allot of us pause just before the power goes out to avoid the hotend from remelting other layers and reduce lines.

When pausing on the normal printer firmware, the head just moves on the YX axis, not the z.
When pausing on the sonic pad it raises the Z axis (to avoid collisions)

But if there is a power cut, and the print was paused, the printer resumes the print at the last Z axis level.


Would be great if someone could add some code to the resume function, to lift the head before moving back to the part